### PR TITLE
fix: Consistent input/output options, and tweak help messages

### DIFF
--- a/misc/MapDMGlen.cpp
+++ b/misc/MapDMGlen.cpp
@@ -30,12 +30,12 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Fragment Length converter - converting MapDamage 2.0 lgdistribution files into NGSNGS length distribution format\n\n");
   fprintf(fp,"Usage\n./LenConvert -i <MapDamage Length Distribution> -o <NGSNGS length distribution file>\n");
   fprintf(fp,"\nExample\n./LenConvert -i lgdistribution.txt -o Ancient_hg19_CDF.txt\n");
-  fprintf(fp,"./LenConvert --MapDMG_in lgdistribution.txt --NGSNGS_out Ancient_hg19_CDF.txt\n");
+  fprintf(fp,"./LenConvert --input lgdistribution.txt --output Ancient_hg19_CDF.txt\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h   | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v   | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i   | --MapDMG_in: \t\t MapDamage fragment length intput in .txt format or .txt.gz\n");
-  fprintf(fp,"-o   | --NGSNGS_out: \t\t NGSNGS fragment length output in .txt format\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t MapDamage fragment length intput in .txt or .txt.gz format.\n");
+  fprintf(fp,"-o | --output: \t NGSNGS fragment length output in .txt format.\n");
   exit(1);
   return 0;
 }
@@ -47,10 +47,10 @@ argStruct *getpars(int argc,char ** argv){
   ++argv;
   while(*argv){
     //fprintf(stderr,"ARGV %s\n",*argv);
-    if(strcasecmp("-i",*argv)==0 || strcasecmp("--MapDMG_in",*argv)==0){
+    if(strcasecmp("-i",*argv)==0 || strcasecmp("--input",*argv)==0){
       mypars->MapDMG_len_in = strdup(*(++argv));
     }
-    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--NGSNGS_out",*argv)==0){
+    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--output",*argv)==0){
       mypars->NGSNGS_len_out = strdup(*(++argv));
     }
     else{

--- a/misc/MapDMGmis.cpp
+++ b/misc/MapDMGmis.cpp
@@ -31,12 +31,12 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Creates a global genome misincorporation file - not chromosome specific.\n\n");
   fprintf(fp,"Usage\n./MisConvert -i <MapDamage Misincorporation file> -o <NGSNGS misincorporation file>\n");
   fprintf(fp,"\nExample\n./MisConvert -i misincorporation.txt -o NGSNGS_mis.txt\n");
-  fprintf(fp,"./MisConvert --MapDMG_in misincorporation.txt --NGSNGS_out NGSNGS_mis.txt\n");
+  fprintf(fp,"./MisConvert --input misincorporation.txt --output NGSNGS_mis.txt\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h   | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v   | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i   | --MapDMG_in: \t\t MapDamage misincorporation input file in .txt format or .txt.gz\n");
-  fprintf(fp,"-o   | --NGSNGS_out: \t\t NGSNGS misincorporation output file in .txt format\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t MapDamage misincorporation input file in .txt or .txt.gz format.\n");
+  fprintf(fp,"-o | --output: \t NGSNGS misincorporation output file in .txt format.\n");
   exit(1);
   return 0;
 }
@@ -48,10 +48,10 @@ argStruct *getpars(int argc,char ** argv){
   ++argv;
   while(*argv){
     //fprintf(stderr,"ARGV %s\n",*argv);
-    if(strcasecmp("-i",*argv)==0 || strcasecmp("--MapDMG_in",*argv)==0){
+    if(strcasecmp("-i",*argv)==0 || strcasecmp("--input",*argv)==0){
       mypars->MapDMG_mis_in = strdup(*(++argv));
     }
-    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--NGSNGS_out",*argv)==0){
+    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--output",*argv)==0){
       mypars->NGSNGS_mis_out = strdup(*(++argv));
     }
     else{

--- a/misc/MetaDMGdeam.cpp
+++ b/misc/MetaDMGdeam.cpp
@@ -31,12 +31,12 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Creates a global genome misincorporation file - not chromosome specific.\n\n");
   fprintf(fp,"Usage\n./MetaMisConvert -i <MetaDamage Misincorporation file> -o <NGSNGS misincorporation file>\n");
   fprintf(fp,"\nExample\n./MetaMisConvert -i MetaNtSub.txt -o NGSNGS_mis.txt\n");
-  fprintf(fp,"./MetaMisConvert --MetaDMG_in MetaNtSub.txt --NGSNGS_out NGSNGS_mis.txt\n");
+  fprintf(fp,"./MetaMisConvert --input MetaNtSub.txt --output NGSNGS_mis.txt\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h   | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v   | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i   | --MetaDMG_in: \t\t MetaDamage misincorporation input file in .txt format or .txt.gz\n");
-  fprintf(fp,"-o   | --NGSNGS_out: \t\t NGSNGS misincorporation output file in .txt format\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t MetaDamage misincorporation input file in .txt or .txt.gz format.\n");
+  fprintf(fp,"-o | --output: \t NGSNGS misincorporation output file in .txt format.\n");
   exit(1);
   return 0;
 }
@@ -48,10 +48,10 @@ argStruct *getpars(int argc,char ** argv){
   ++argv;
   while(*argv){
     //fprintf(stderr,"ARGV %s\n",*argv);
-    if(strcasecmp("-i",*argv)==0 || strcasecmp("--MetaDMG_in",*argv)==0){
+    if(strcasecmp("-i",*argv)==0 || strcasecmp("--input",*argv)==0){
       mypars->MetaDMG_mis_in = strdup(*(++argv));
     }
-    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--NGSNGS_out",*argv)==0){
+    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--output",*argv)==0){
       mypars->NGSNGS_mis_out = strdup(*(++argv));
     }
     else{

--- a/misc/RandRef.cpp
+++ b/misc/RandRef.cpp
@@ -31,15 +31,15 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Usage\n./RandRef -l <Genome Length> -s <seed> -n <Chromosome number> -o <output name>\n");
   fprintf(fp,"\nExample\n./RandRef -l 1000000 -s 1 -n 2 -nn -o RandRefChr1S1.fa\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h    | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v    | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-l    | --length: \t\t Reference genome .fa format\n");
-  fprintf(fp,"-s    | --seed: \t\t\t seed for random generators\n");
-  fprintf(fp,"-n    | --chrNo: \t\t Number of chromosomes'\n");
-  fprintf(fp,"-nn   | --NoNt: \t\t Simulate sequence without the character N'\n");
-  fprintf(fp,"-nstop| --NoStopCodon: \t\t\t Creates no variation resulting in stop codons <TAG,TAA,TGA>\n");
-  fprintf(fp,"-iter | --iterations: \t\t\t Number of times the stop codon replacements are performed (Due to triplets, replacement of one stop codon might lead to another), default = 2\n");
-  fprintf(fp,"-o    | --output: \t\t Randomly simulated reference genome .fa\n");
+  fprintf(fp,"-h    | --help: \t Print help page.\n");
+  fprintf(fp,"-v    | --version: \t Print version.\n\n");
+  fprintf(fp,"-l    | --length: \t Length of genome.\n");
+  fprintf(fp,"-s    | --seed: \t Seed for random generators.\n");
+  fprintf(fp,"-n    | --chrNo: \t Number of chromosomes.\n");
+  fprintf(fp,"-nn   | --NoNt: \t Simulate sequences without the character N.\n");
+  fprintf(fp,"-nstop| --NoStopCodon: \t Creates no variation resulting in stop codons <TAG,TAA,TGA>.\n");
+  fprintf(fp,"-iter | --iterations: \t Number of times the stop codon replacements are performed (Due to triplets, replacement of one stop codon might lead to another), default = 2.\n");
+  fprintf(fp,"-o    | --output: \t Randomly simulated reference genome in FASTA format.\n");
   exit(1);
   return 0;
 }

--- a/misc/RandVariant.cpp
+++ b/misc/RandVariant.cpp
@@ -29,14 +29,14 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Usage\n./RandVar -i <Reference> -s <seed> -n <Number of random variations> -p <Position information> -o <Reference genome with variations>\n");
   fprintf(fp,"\nExample\n./RandVar -i RandRefChr1S1.fa -s 10 -n 1000000 -p position.txt -o RandRefChr1S1Var.fa\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h    | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v    | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i    | --input: \t\t Reference genome .fa format\n");
-  fprintf(fp,"-s    | --seed: \t\t\t seed for random generators\n");
-  fprintf(fp,"-n    | --number: \t\t Number of stochastic variations to be included in the input reference, conflicts with -m|--modulus\n");
-  fprintf(fp,"-m    | --modulus: \t\t Every N'th position to be altered, conflicts with -n|--number\n");
-  fprintf(fp,"-p    | --pos: \t\t\t Internal txt file with chromomsomal coordinate for the incorporated variations\n");
-  fprintf(fp,"-o    | --output: \t\t Altered reference genomes saved as .fa\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t Reference genome in FASTA format.\n");
+  fprintf(fp,"-s | --seed: \t Seed for random generators.\n");
+  fprintf(fp,"-n | --number: \t Number of stochastic variations to be included in the input reference, conflicts with -m|--modulus.\n");
+  fprintf(fp,"-m | --modulus:  Every N'th position to be altered, conflicts with -n|--number.\n");
+  fprintf(fp,"-p | --pos: \t Output chromomsomal coordinates for the incorporated variations in plain text.\n");
+  fprintf(fp,"-o | --output: \t Altered reference genomes saved as .fa\n");
   exit(1);
   return 0;
 }
@@ -141,7 +141,7 @@ int Reference_Variant(int argc,char **argv){
       char buf[1024];
 
       FILE *fp;
-	    fp = fopen(Coord_file, "w");
+      fp = fopen(Coord_file, "w");
 
       char **data = (char **)malloc(var_operations * sizeof(char *));
       int data_count = 0;

--- a/misc/ReadQualConverter.cpp
+++ b/misc/ReadQualConverter.cpp
@@ -30,12 +30,12 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Read Quality Profile converter - converting ART profiles to NGSNGS format\n\n");
   fprintf(fp,"Usage\n./QualConvert -i <ART platform profile> -o <NGSNGS quality profile>\n");
   fprintf(fp,"\nExample\n./QualConvert -i HiSeq2500L150R1filter.txt -o HiSeq2500L150R1_CDF.txt\n");
-  fprintf(fp,"./QualConvert --Art_in HiSeq2500L150R1filter.txt --NGSNGS_out HiSeq2500L150R1_CDF.txt\n");
+  fprintf(fp,"./QualConvert --input HiSeq2500L150R1filter.txt --output HiSeq2500L150R1_CDF.txt\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h   | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v   | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i   | --Art_in: \t\t ART platform profile intput in .txt format or .txt.gz\n");
-  fprintf(fp,"-o   | --NGSNGS_out: \t\t NGSNGS nucletide quality profile in .txt format\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t ART platform profile intput in .txt or .txt.gz format.\n");
+  fprintf(fp,"-o | --output: \t NGSNGS nucletide quality profile in .txt format.\n");
   exit(1);
   return 0;
 }
@@ -47,10 +47,10 @@ argStruct *getpars(int argc,char ** argv){
   ++argv;
   while(*argv){
     //fprintf(stderr,"ARGV %s\n",*argv);
-    if(strcasecmp("-i",*argv)==0 || strcasecmp("--Art_in",*argv)==0){
+    if(strcasecmp("-i",*argv)==0 || strcasecmp("--input",*argv)==0){
       mypars->ART_qual_nt_profile_in = strdup(*(++argv));
     }
-    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--NGSNGS_out",*argv)==0){
+    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--output",*argv)==0){
       mypars->NGSNGS_qual_nt_profile_out = strdup(*(++argv));
     }
     else{

--- a/misc/RemoveCodon.cpp
+++ b/misc/RemoveCodon.cpp
@@ -30,15 +30,15 @@ int HelpPage(FILE *fp){
   fprintf(fp,"Usage\n./RemoveCodon -i <Reference> -s <seed> -iter <No. Replacment iterations> --codon <Codon to be replaced> --codonout <The desired codon> -o <Reference genome with removed codons>\n");
   fprintf(fp,"\nExample\n./RemoveCodon -i RandRefChr1S1Var.fa -o RandRefChr1S1Stop.fa -s 10 -iter 10 --codon AGT --codonout GAT\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h    | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v    | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-i    | --input: \t\t Reference genome .fa format\n");
-  fprintf(fp,"-o    | --output: \t\t Altered reference genomes with the removed codons saved as .fa\n");
-  fprintf(fp,"--codon \t\t Specify which codon should be removed, if used alone a random replacement will occur\n");
-  fprintf(fp,"--codonout \t\t Specify which --codon should be removed, and replaced by specified --codonout\n");
-  fprintf(fp,"--stop \t\t Replace all stop codons with randomly generated codons\n");
-  fprintf(fp,"-s    | --seed: \t\t\t seed for random generators\n");
-  fprintf(fp,"-iter | --iterations: \t\t\t Number of times the codon replacements are performed (Due to triplets, replacement of one stop codon might lead to another), default = 5\n");
+  fprintf(fp,"-h    | --help: \t Print help page.\n");
+  fprintf(fp,"-v    | --version: \t Print version.\n\n");
+  fprintf(fp,"-i    | --input: \t Reference genome in FASTA format.\n");
+  fprintf(fp,"-o    | --output: \t Altered reference genomes in FASTA format, without the specified codons.\n");
+  fprintf(fp,"--codon \t\t Specify which codon should be removed, if used alone a random replacement will occur.\n");
+  fprintf(fp,"--codonout \t\t Specify which --codon should be removed, and replaced by specified --codonout.\n");
+  fprintf(fp,"--stop \t\t\t Replace all stop codons with randomly generated codons.\n");
+  fprintf(fp,"-s    | --seed: \t seed for random generators.\n");
+  fprintf(fp,"-iter | --iterations: \t Number of times the codon replacements are performed (Due to triplets, replacement of one stop codon might lead to another), default = 5.\n");
   exit(1);
   return 0;
 }

--- a/misc/VCFtoBED.cpp
+++ b/misc/VCFtoBED.cpp
@@ -24,15 +24,15 @@ typedef struct{
 
 int HelpPage(FILE *fp){
   fprintf(fp,"Stochastic variation on input reference genome\n");
-  fprintf(fp,"Usage\n./VCFtoBED -vcf <vcf_file> -r <range before and after vcf position> -o <Output file name for BED>\n");
-  fprintf(fp,"\nExample\n./VCFtoBED -vcf ../Test_Examples/ChrMtSubDeletionDiploid.vcf -bed ChrMtSubDeletionDiploid.bed -r 50 -id 0\n");
+  fprintf(fp,"Usage\n./VCFtoBED -i <vcf_file> -r <range before and after vcf position> -o <Output file name for BED>\n");
+  fprintf(fp,"\nExample\n./VCFtoBED --input ../Test_Examples/ChrMtSubDeletionDiploid.vcf --output ChrMtSubDeletionDiploid.bed -r 50 -id 0\n");
   fprintf(fp,"\nOptions: \n");
-  fprintf(fp,"-h   | --help: \t\t\t Print help page.\n");
-  fprintf(fp,"-v   | --version: \t\t Print help page.\n\n");
-  fprintf(fp,"-vcf | --vcfin: \t\t The input vcf file containing positions with variants\n");
-  fprintf(fp,"-bed | --bedout: \t\t The output name for the created bed file with only regions present in the vcf file\n");
-  fprintf(fp,"-r | --range: \t\t Integer value specifying the number of nucleotides before and after the vcf position, default = 35\n");
-  fprintf(fp,"-id \t\t Integer value specifying the index of individuals present in header, default = 0\n");
+  fprintf(fp,"-h | --help: \t Print help page.\n");
+  fprintf(fp,"-v | --version:  Print version.\n\n");
+  fprintf(fp,"-i | --input: \t VCF file containing positions with variants.\n");
+  fprintf(fp,"-o | --output: \t BED file with only regions present in the VCF file.\n");
+  fprintf(fp,"-r | --range: \t Integer value specifying the number of nucleotides before and after each VCF position, default = 35.\n");
+  fprintf(fp,"--id \t\t Integer value specifying which individual from the VCF to use, default = 0.\n");
   exit(1);
   return 0;
 }
@@ -47,16 +47,16 @@ argStruct *getpars(int argc,char ** argv){
   ++argv;
   while(*argv){
     //fprintf(stderr,"ARGV %s\n",*argv);
-    if(strcasecmp("-vcf",*argv)==0 || strcasecmp("--vcfin",*argv)==0){
+    if(strcasecmp("-i",*argv)==0 || strcasecmp("--input",*argv)==0){
       mypars->bcffilename = strdup(*(++argv));
     }
-    else if(strcasecmp("-bed",*argv)==0 || strcasecmp("--bedout",*argv)==0){
+    else if(strcasecmp("-o",*argv)==0 || strcasecmp("--output",*argv)==0){
       mypars->bedfilename = strdup(*(++argv));
     }
     else if(strcasecmp("-r",*argv)==0 || strcasecmp("--range",*argv)==0){
       mypars->range = atoi(*(++argv));
     }
-    else if(strcasecmp("-id",*argv)==0){
+    else if(strcasecmp("--id",*argv)==0){
       mypars->id = atoi(*(++argv));
     }
     else{


### PR DESCRIPTION

For consistency, changed input and output options to  `--input` and `--output`.
Several fixes to the help messages.