### PR TITLE
Fix stack overflows

### DIFF
--- a/Briggs2.cpp
+++ b/Briggs2.cpp
@@ -58,7 +58,7 @@ int SimBriggsModel2(char *ori, int L, double nv, double lambda, double delta_s, 
   
   strncpy(rasmus,ori,L);
   strncpy(thorfinn,ori,L);
-  Complement(thorfinn,strlen(thorfinn));
+  Complement(thorfinn);
   
   if (rasmus[0] == 'C'|| rasmus[0] == 'c' ){C_total++;G_total++;}
   if (thorfinn[L-1] == 'C'|| thorfinn[L-1] == 'c' ){C_total++;G_total++;}

--- a/NGSNGS_misc.cpp
+++ b/NGSNGS_misc.cpp
@@ -1,19 +1,8 @@
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
-#include <ctime>
-#include <cassert>
-#include <cstdint>
-#include <iostream>
-#include <cmath>
 #include <algorithm>
+#include <cstring>
 
-#include "RandSampling.h"
-#include "mrand.h"
 #include "NGSNGS_misc.h"
 
-#define LENS 10000
-#define MAXBINS 100
 int refToInt[256] = {
   0,1,2,3,4,4,4,4,4,4,4,4,4,4,4,4,//15
   4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,//31
@@ -58,53 +47,17 @@ char NtComp[5] = {'T', 'G', 'C', 'A','N'};
 
 const char *bass = "ACGTN";
 
-void ReversComplement(char seq[]){
-  // generates the reverse complementary sequence from an input sequence
-  char seq_intermediate[LENS];
-  strcpy(seq_intermediate,seq);
-  int seqlen = strlen(seq);
-  //Complementing sequence
-  for(int i=0;i<seqlen;i++){
-    seq_intermediate[i] = NtComp[refToInt[(unsigned char) seq_intermediate[i]]]; //warning: array subscript has type 'char' [-Wchar-subscripts]
-  }
-  //reverse complement
-  for(int i=seqlen-1;i>-1;i--){
-    seq[seqlen-i-1] = seq_intermediate[i];
-  }
-  //Clearing out the intermediate sequence
-  memset(seq_intermediate, 0, sizeof seq_intermediate);
+void ReversComplement(char* seq) {
+  // Reverse and complement input sequence in place
+  reverseChar(seq, strlen(seq));
+  Complement(seq);
 }
 
-void ReversComplement2(char seq[],size_t fraglength){
-  // generates the reverse complementary sequence from an input sequence
-  char seq_intermediate[fraglength];
-  strcpy(seq_intermediate,seq);
-  int seqlen = strlen(seq);
-  //Complementing sequence
-  for(int i=0;i<seqlen;i++){
-    seq_intermediate[i] = NtComp[refToInt[(unsigned char) seq_intermediate[i]]]; //warning: array subscript has type 'char' [-Wchar-subscripts]
+void Complement(char* seq) {
+  // Complemen input sequence in place
+  for (; *seq; ++seq) {
+    *seq = NtComp[refToInt[(unsigned char)*seq]];
   }
-  //reverse complement
-  for(int i=seqlen-1;i>-1;i--){
-    seq[seqlen-i-1] = seq_intermediate[i];
-  }
-  //Clearing out the intermediate sequence
-  memset(seq_intermediate, 0, sizeof seq_intermediate);
-}
-
-void Complement(char seq[],size_t fraglength){
-  // generates the complementary sequence from an input sequence
-  char seq_intermediate[fraglength];
-  strcpy(seq_intermediate,seq);
-  int seqlen = strlen(seq);
-  //Complementing sequence
-  for(int i=0;i<seqlen;i++){
-    seq_intermediate[i] = NtComp[refToInt[(unsigned char) seq_intermediate[i]]]; //warning: array subscript has type 'char' [-Wchar-subscripts]
-    seq[i] = seq_intermediate[i];
-  }
-
-  //Clearing out the intermediate sequence
-  memset(seq_intermediate, 0, sizeof seq_intermediate);
 }
 
 void reverseChar(char* str,int length) {

--- a/NGSNGS_misc.h
+++ b/NGSNGS_misc.h
@@ -1,13 +1,9 @@
 #ifndef NGSNGS_MISC_H
 #define NGSNGS_MISC_H
-#include "mrand.h"
-#include "RandSampling.h"
 
-void ReversComplement(char seq[]);
+void ReversComplement(char* seq);
 
-void ReversComplement2(char seq[],size_t fraglength);
-
-void Complement(char seq[],size_t fraglength);
+void Complement(char* seq);
 
 void reverseChar(char* str,int length);
 

--- a/Sampling.cpp
+++ b/Sampling.cpp
@@ -272,10 +272,7 @@ void* Sampling_threads(void *arg) {
         FragRes[i] = FragmentSequence;
       }
     }
-
-    int chr_idx_array[struct_obj->Duplicates];
-    for (int i = 0; i < struct_obj->Duplicates; i++){chr_idx_array[struct_obj->Duplicates]=chr_idx;}
-    
+   
     for (int FragNo = 0+Groupshift; FragNo < FragTotal; FragNo+=iter){
       qual_r1[0] = qual_r2[0] = seq_r1[0] = seq_r2[0] = '\0';
 
@@ -516,37 +513,36 @@ void* Sampling_threads(void *arg) {
           strcat(READ_ID,suffR1);
           int chr_max_end_mate = 0; //PNEXT 0-> unavailable for SE
           int insert_mate = 0; //TLEN
-          int chr_idx_mate = -1;
+          int chr_idx_read = chr_idx;
           if(PE==struct_obj->SeqType){
             strcat(READ_ID2,suffR2);
             if (struct_obj->Align == 0){
               mapq = 255;
               SamFlags[0] = SamFlags[1] = 4;
-              chr_idx_array[struct_obj->Duplicates] = -1;
+              chr_idx_read = -1;
               chr_max_end_mate = 0;
             }
             else{
               chr_max_end_mate = max_end;
               insert_mate = insert;
-              chr_idx_mate = chr_idx_array[struct_obj->Duplicates];
             }        
           }
           if (struct_obj->Align == 0){
             mapq = 255;
             SamFlags[0] = SamFlags[1] = 4;
-            chr_idx_array[struct_obj->Duplicates] = -1;
+            chr_idx_read = -1;
             min_beg = -1;
             max_end = 0;
           }
 
           //we have set the parameters accordingly above for no align and PE
-          bam_set1(struct_obj->list_of_reads[struct_obj->LengthData++],strlen(READ_ID),READ_ID,SamFlags[0],chr_idx_array[struct_obj->Duplicates],min_beg,mapq,
-                n_cigar[0],AlignCigar[0],chr_idx_mate,chr_max_end_mate-1,insert_mate,strlen(seq_r1),seq_r1,qual_r1,l_aux);
+          bam_set1(struct_obj->list_of_reads[struct_obj->LengthData++],strlen(READ_ID),READ_ID,SamFlags[0],chr_idx_read,min_beg,mapq,
+                n_cigar[0],AlignCigar[0],chr_idx_read,chr_max_end_mate-1,insert_mate,strlen(seq_r1),seq_r1,qual_r1,l_aux);
 
           //write PE also
           if (PE==struct_obj->SeqType){
-            bam_set1(struct_obj->list_of_reads[struct_obj->LengthData++],strlen(READ_ID2),READ_ID2,SamFlags[1],chr_idx_array[struct_obj->Duplicates],max_end-1,mapq,
-              n_cigar[1],AlignCigar[1],chr_idx_array[struct_obj->Duplicates],min_beg,0-insert_mate,strlen(seq_r2),seq_r2,qual_r2,l_aux);
+            bam_set1(struct_obj->list_of_reads[struct_obj->LengthData++],strlen(READ_ID2),READ_ID2,SamFlags[1],chr_idx_read,max_end-1,mapq,
+              n_cigar[1],AlignCigar[1],chr_idx_read,min_beg,0-insert_mate,strlen(seq_r2),seq_r2,qual_r2,l_aux);
           }
         
           if (struct_obj->LengthData < struct_obj->MaximumLength){   


### PR DESCRIPTION
These commits fixes stack overflows
 * in `Complement` due to not allocating space for the null terminator
 * in `ReversComplement` if `strlen(seq) > LENS`
 * and in `Sampling_threads` due to allocating too few elements for `chr_idx_array`. 

For `Complement` and `ReversComplement` I greatly simplified the algorithm so that it runs in place and I also removed a substantial amount of unused headers in `NGSNGS_misc.*`.

Overflows due to potential mismatches between `fraglength` and `strlen(seq)` are also avoided by removing the `fraglength` parameter and I also removed the unused `ReversComplement2` function. But if this functionality is needed then it can easily be re-added while still avoiding code duplication.